### PR TITLE
Optional dependencies for sidekiq/resque

### DIFF
--- a/sunspot-queue.gemspec
+++ b/sunspot-queue.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "sunspot_rails",            ">= 1.3.0"
 
-  s.add_runtime_dependency "resque"
-  s.add_runtime_dependency "sidekiq"
+  s.add_development_dependency "resque"
+  s.add_development_dependency "sidekiq"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec",        "~> 2.11.0"


### PR DESCRIPTION
Would it be possible to change resque and sidekiq to optional dependencies, rather than runtime dependencies? Currently, including sunspot-queue includes both the resque and sidekiq gems in your bundle, since it says it depends on both of them. Since the user has to specify which backend they want to use anyhow, why require those as hard dependencies?
