### PR TITLE
Allow configurable index/removal jobs

### DIFF
--- a/lib/sunspot/queue.rb
+++ b/lib/sunspot/queue.rb
@@ -2,8 +2,17 @@ module Sunspot
   module Queue
     class Error < StandardError; end
     class NotPersistedError < Error; end
+
+    def self.configure(&blk)
+      yield configuration
+    end
+
+    def self.configuration
+      @configuration ||= Sunspot::Queue::Configuration.new
+    end
   end
 end
 
 require "sunspot/queue/version"
+require "sunspot/queue/configuration"
 require "sunspot/queue/session_proxy"

--- a/lib/sunspot/queue/configuration.rb
+++ b/lib/sunspot/queue/configuration.rb
@@ -1,0 +1,23 @@
+module Sunspot::Queue
+  class Configuration
+    attr_accessor \
+      :resque_index_job, :resque_removal_job,
+      :sidekiq_index_job, :sidekiq_removal_job
+
+    def resque_index_job
+      @resque_index_job ||= ::Sunspot::Queue::Resque::IndexJob
+    end
+
+    def resque_removal_job
+      @resque_removal_job ||= ::Sunspot::Queue::Resque::RemovalJob
+    end
+
+    def sidekiq_index_job
+      @sidekiq_index_job ||= ::Sunspot::Queue::Sidekiq::IndexJob
+    end
+
+    def sidekiq_removal_job
+      @sidekiq_removal_job ||= ::Sunspot::Queue::Sidekiq::RemovalJob
+    end
+  end
+end

--- a/lib/sunspot/queue/resque/backend.rb
+++ b/lib/sunspot/queue/resque/backend.rb
@@ -4,16 +4,22 @@ require "sunspot/queue/resque/removal_job"
 
 module Sunspot::Queue::Resque
   class Backend
+    attr_reader :configuration
+
+    def initialize(configuration=Sunspot::Queue.configuration)
+      @configuration = configuration
+    end
+
     def enqueue(job, klass, id)
       ::Resque.enqueue(job, klass, id)
     end
 
     def index(klass, id)
-      enqueue(::Sunspot::Queue::Resque::IndexJob, klass, id)
+      enqueue(configuration.resque_index_job, klass, id)
     end
 
     def remove(klass, id)
-      enqueue(::Sunspot::Queue::Resque::RemovalJob , klass, id)
+      enqueue(configuration.resque_removal_job, klass, id)
     end
   end
 end

--- a/lib/sunspot/queue/sidekiq/backend.rb
+++ b/lib/sunspot/queue/sidekiq/backend.rb
@@ -3,17 +3,23 @@ require "sunspot/queue/sidekiq/removal_job"
 
 module Sunspot::Queue::Sidekiq
   class Backend
+    attr_reader :configuration
+
+    def initialize(configuration=Sunspot::Queue.configuration)
+      @configuration = configuration
+    end
+
     # Job needs to include Sidekiq::Worker
     def enqueue(job, klass, id)
       job.perform_async(klass, id)
     end
 
     def index(klass, id)
-      ::Sunspot::Queue::Sidekiq::IndexJob.perform_async(klass, id)
+      configuration.sidekiq_index_job.perform_async(klass, id)
     end
 
     def remove(klass, id)
-      ::Sunspot::Queue::Sidekiq::RemovalJob.perform_async(klass, id)
+      configuration.sidekiq_removal_job.perform_async(klass, id)
     end
   end
 end

--- a/spec/sunspot/queue/configuration_spec.rb
+++ b/spec/sunspot/queue/configuration_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Sunspot::Queue::Configuration do
+  subject(:configuration){ described_class.new }
+
+  describe "#resque_index_job" do
+    it "defaults to ::Sunspot::Queue::Resque::IndexJob" do
+      configuration.resque_index_job.should eq(::Sunspot::Queue::Resque::IndexJob)
+    end
+
+    it "can be set to a custom job" do
+      expect {
+        configuration.resque_index_job = "MyCustomIndexJob"
+      }.to change(configuration, :resque_index_job).to("MyCustomIndexJob")
+    end
+  end
+
+  describe "#sidekiq_index_job" do
+    it "defaults to ::Sunspot::Queue::Sidekiq::IndexJob" do
+      configuration.sidekiq_index_job.should eq(::Sunspot::Queue::Sidekiq::IndexJob)
+    end
+
+    it "can be set to a custom job" do
+      expect {
+        configuration.sidekiq_index_job = "MyCustomIndexJob"
+      }.to change(configuration, :sidekiq_index_job).to("MyCustomIndexJob")
+    end
+  end
+end

--- a/spec/sunspot/queue/resque/backend_spec.rb
+++ b/spec/sunspot/queue/resque/backend_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module Sunspot::Queue::Resque
+  class SampleModel ; end
+
+  describe Backend do
+    subject(:backend){ described_class.new(configuration) }
+    let(:configuration){ double("Configuration") }
+
+    describe "#index" do
+      let(:index_job){ double("Resque Job") }
+
+      before do
+        configuration.stub(:resque_index_job).and_return index_job
+      end
+
+      it "enqueues a job in Resque using the configuration's resque_index_job" do
+        ::Resque::should_receive(:enqueue).with(index_job, SampleModel, 3)
+        backend.index(SampleModel, 3)
+      end
+    end
+
+    describe "#remove" do
+      let(:removal_job){ double("Resque Job") }
+
+      before do
+        configuration.stub(:resque_index_job).and_return removal_job
+      end
+
+      it "enqueues a job in Resque using the configuration's resque_index_job" do
+        ::Resque::should_receive(:enqueue).with(removal_job, SampleModel, 7)
+        backend.index(SampleModel, 7)
+      end
+    end
+
+  end
+end

--- a/spec/sunspot/queue/sidekiq/backend_spec.rb
+++ b/spec/sunspot/queue/sidekiq/backend_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module Sunspot::Queue::Sidekiq
+  class SampleModel ; end
+
+  describe Backend do
+    subject(:backend){ described_class.new(configuration) }
+    let(:configuration){ double("Configuration") }
+
+    describe "#index" do
+      let(:index_job){ double("Sidekiq Job") }
+
+      before do
+        configuration.stub(:sidekiq_index_job).and_return index_job
+      end
+
+      it "enqueues a job in Resque using the configuration's sidekiq_index_job" do
+        index_job.should_receive(:perform_async).with(SampleModel, 9)
+        backend.index(SampleModel, 9)
+      end
+    end
+
+    describe "#remove" do
+      let(:removal_job){ double("Sidekiq Job") }
+
+      before do
+        configuration.stub(:sidekiq_index_job).and_return removal_job
+      end
+
+      it "enqueues a job in Resque using the configuration's sidekiq_removal_job" do
+        removal_job.should_receive(:perform_async).with(SampleModel, 11)
+        backend.index(SampleModel, 11)
+      end
+    end
+  end
+
+end

--- a/spec/sunspot/queue_spec.rb
+++ b/spec/sunspot/queue_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Sunspot::Queue do
+
+  describe "#configuration" do
+    it "returns a default configuration" do
+      config = Sunspot::Queue.configuration
+      config.should be_kind_of(Sunspot::Queue::Configuration)
+    end
+
+    it "returns the same same configuration when requested multiple times" do
+      config = Sunspot::Queue.configuration
+      Sunspot::Queue.configuration.should be(config)
+      Sunspot::Queue.configuration.should be(config)
+    end
+  end
+
+  describe "#configure(&blk)" do
+    it "yields the configuration to a block" do
+      config = Sunspot::Queue.configuration
+      expect { |blk|
+        Sunspot::Queue.configure(&blk)
+      }.to yield_with_args(config)
+    end
+  end
+
+  describe "defaults" do
+  end
+
+end


### PR DESCRIPTION
The above change-set allows the default index/removal jobs for resque and sidekiq to be overridden via the following syntax:

```
Sunspot::Queue.configure do |c|
  c.resque_index_job = MyCustomIndexJob
  c.resque_removal_job = MyCustomRemovalJob
  c.sidekiq_index_job = MySidekiqIndexJob
  c.sidekiq_removal_job = MySidekidRemovalJob
end
```

Or without a block accessing the configuration object directly:

```
Sunspot::Queue.configuration.resque_index_job = MyCustomIndexJob
```

There are default jobs provided based on what was being used.
