### PR TITLE
without_proxy helper method should allow subclasses of Sunspot::Queue::SessionProxy as well

### DIFF
--- a/lib/sunspot/queue/helpers.rb
+++ b/lib/sunspot/queue/helpers.rb
@@ -7,7 +7,7 @@ module Sunspot::Queue
 
       # Pop off the queueing proxy for the block if it's in place so we don't
       # requeue the same job multiple times.
-      if Sunspot.session.instance_of?(SessionProxy)
+      if Sunspot.session.is_a?(SessionProxy)
         proxy = Sunspot.session
         Sunspot.session = proxy.session
       end


### PR DESCRIPTION
I've customized the behaviour of the SessionProxy by subclassing it in my Rails application. However, each job now only recreates the same job and never gets to actually indexing something. This changes the without_proxy to also allow subclasses of SessionProxy.
