### PR TITLE
Index and remove using sunspot autocommit

### DIFF
--- a/lib/sunspot/queue.rb
+++ b/lib/sunspot/queue.rb
@@ -13,6 +13,8 @@ module Sunspot
   end
 end
 
+require "sunspot/queue/index"
+require "sunspot/queue/removal"
 require "sunspot/queue/version"
 require "sunspot/queue/configuration"
 require "sunspot/queue/session_proxy"

--- a/lib/sunspot/queue/delayed_job/index_job.rb
+++ b/lib/sunspot/queue/delayed_job/index_job.rb
@@ -5,9 +5,7 @@ module Sunspot::Queue::DelayedJob
     include ::Sunspot::Queue::Helpers
 
     def perform
-      without_proxy do
-        Sunspot.index! [constantize(klass).find(id)]
-      end
+      Sunspot::Queue::Index.index klass, id
     end
   end
 end

--- a/lib/sunspot/queue/delayed_job/index_job.rb
+++ b/lib/sunspot/queue/delayed_job/index_job.rb
@@ -6,7 +6,7 @@ module Sunspot::Queue::DelayedJob
 
     def perform
       without_proxy do
-        constantize(klass).find(id).solr_index
+        Sunspot.index! [constantize(klass).find(id)]
       end
     end
   end

--- a/lib/sunspot/queue/delayed_job/removal_job.rb
+++ b/lib/sunspot/queue/delayed_job/removal_job.rb
@@ -6,7 +6,7 @@ module Sunspot::Queue::DelayedJob
 
     def perform
       without_proxy do
-        ::Sunspot.remove_by_id(klass, id)
+        ::Sunspot.remove_by_id!(klass, id)
       end
     end
   end

--- a/lib/sunspot/queue/delayed_job/removal_job.rb
+++ b/lib/sunspot/queue/delayed_job/removal_job.rb
@@ -5,9 +5,7 @@ module Sunspot::Queue::DelayedJob
     include ::Sunspot::Queue::Helpers
 
     def perform
-      without_proxy do
-        ::Sunspot.remove_by_id!(klass, id)
-      end
+      Sunspot::Queue::Removal.remove klass, id
     end
   end
 end

--- a/lib/sunspot/queue/index.rb
+++ b/lib/sunspot/queue/index.rb
@@ -1,0 +1,13 @@
+require "sunspot/queue/helpers"
+
+module Sunspot::Queue
+  module Index
+    extend ::Sunspot::Queue::Helpers
+
+    def self.index(klass, id)
+      without_proxy do
+        Sunspot.index! [constantize(klass).find(id)]
+      end
+    end
+  end
+end

--- a/lib/sunspot/queue/removal.rb
+++ b/lib/sunspot/queue/removal.rb
@@ -1,0 +1,13 @@
+require "sunspot/queue/helpers"
+
+module Sunspot::Queue
+  module Removal
+    extend ::Sunspot::Queue::Helpers
+
+    def self.remove(klass, id)
+      without_proxy do
+        ::Sunspot.remove_by_id!(klass, id)
+      end
+    end
+  end
+end

--- a/lib/sunspot/queue/resque/index_job.rb
+++ b/lib/sunspot/queue/resque/index_job.rb
@@ -9,9 +9,7 @@ module Sunspot::Queue::Resque
     end
 
     def self.perform(klass, id)
-      without_proxy do
-        Sunspot.index! [constantize(klass).find(id)]
-      end
+      Sunspot::Queue::Index.index klass, id
     end
   end
 end

--- a/lib/sunspot/queue/resque/index_job.rb
+++ b/lib/sunspot/queue/resque/index_job.rb
@@ -10,7 +10,7 @@ module Sunspot::Queue::Resque
 
     def self.perform(klass, id)
       without_proxy do
-        constantize(klass).find(id).solr_index
+        Sunspot.index! [constantize(klass).find(id)]
       end
     end
   end

--- a/lib/sunspot/queue/resque/removal_job.rb
+++ b/lib/sunspot/queue/resque/removal_job.rb
@@ -10,7 +10,7 @@ module Sunspot::Queue::Resque
 
     def self.perform(klass, id)
       without_proxy do
-        ::Sunspot.remove_by_id(klass, id)
+        ::Sunspot.remove_by_id!(klass, id)
       end
     end
   end

--- a/lib/sunspot/queue/resque/removal_job.rb
+++ b/lib/sunspot/queue/resque/removal_job.rb
@@ -9,9 +9,7 @@ module Sunspot::Queue::Resque
     end
 
     def self.perform(klass, id)
-      without_proxy do
-        ::Sunspot.remove_by_id!(klass, id)
-      end
+      Sunspot::Queue::Removal.remove klass, id
     end
   end
 end

--- a/lib/sunspot/queue/sidekiq.rb
+++ b/lib/sunspot/queue/sidekiq.rb
@@ -1,3 +1,4 @@
+require "sidekiq"
 require "sunspot/queue"
 
 module Sunspot::Queue

--- a/lib/sunspot/queue/sidekiq/index_job.rb
+++ b/lib/sunspot/queue/sidekiq/index_job.rb
@@ -9,9 +9,7 @@ module Sunspot::Queue::Sidekiq
     sidekiq_options :queue => "sunspot"
 
     def perform(klass, id)
-      without_proxy do
-        Sunspot.index! [constantize(klass).find(id)]
-      end
+      Sunspot::Queue::Index.index klass, id
     end
   end
 end

--- a/lib/sunspot/queue/sidekiq/index_job.rb
+++ b/lib/sunspot/queue/sidekiq/index_job.rb
@@ -10,7 +10,7 @@ module Sunspot::Queue::Sidekiq
 
     def perform(klass, id)
       without_proxy do
-        constantize(klass).find(id).solr_index
+        Sunspot.index! [constantize(klass).find(id)]
       end
     end
   end

--- a/lib/sunspot/queue/sidekiq/removal_job.rb
+++ b/lib/sunspot/queue/sidekiq/removal_job.rb
@@ -10,7 +10,7 @@ module Sunspot::Queue::Sidekiq
 
     def perform(klass, id)
       without_proxy do
-        ::Sunspot.remove_by_id(klass, id)
+        ::Sunspot.remove_by_id!(klass, id)
       end
     end
   end

--- a/lib/sunspot/queue/sidekiq/removal_job.rb
+++ b/lib/sunspot/queue/sidekiq/removal_job.rb
@@ -9,9 +9,7 @@ module Sunspot::Queue::Sidekiq
     sidekiq_options :queue => "sunspot"
 
     def perform(klass, id)
-      without_proxy do
-        ::Sunspot.remove_by_id!(klass, id)
-      end
+      Sunspot::Queue::Removal.remove klass, id
     end
   end
 end

--- a/spec/delayed_job/index_job_spec.rb
+++ b/spec/delayed_job/index_job_spec.rb
@@ -4,7 +4,7 @@ describe Sunspot::Queue::DelayedJob::IndexJob do
   context "ActiveRecord" do
 
     it "indexes an ActiveRecord model" do
-      person = Person.create(:name => "The Grandson") 
+      person = Person.create(:name => "The Grandson")
       job = Sunspot::Queue::DelayedJob::IndexJob.new(Person, person.id)
 
       # This will queue a job but we'll just ignore it to isolate the job
@@ -33,16 +33,12 @@ describe Sunspot::Queue::DelayedJob::IndexJob do
       end.to_not change { Sunspot.session }
     end
 
-    it "does not commit changes to the index" do
+    it "commits changes to the index" do
       person = Person.create(:name => "The Grandson")
       job = Sunspot::Queue::DelayedJob::IndexJob.new(Person, person.id)
 
       expect do
         job.perform
-      end.to_not change { Person.search.hits.size }
-
-      expect do
-        commit
       end.to change { Person.search.hits.size }
     end
   end

--- a/spec/resque/index_job_spec.rb
+++ b/spec/resque/index_job_spec.rb
@@ -33,15 +33,11 @@ describe Sunspot::Queue::Resque::IndexJob do
       end.to_not change { Sunspot.session }
     end
 
-    it "does not commit changes to the index" do
+    it "commits changes to the index" do
       person = Person.create(:name => "The Grandson")
 
       expect do
         job.perform(Person, person.id)
-      end.to_not change { Person.search.hits.size }
-
-      expect do
-        commit
       end.to change { Person.search.hits.size }
     end
   end

--- a/spec/sidekiq/index_job_spec.rb
+++ b/spec/sidekiq/index_job_spec.rb
@@ -25,15 +25,11 @@ describe Sunspot::Queue::Sidekiq::IndexJob do
       end.to_not change { Sunspot.session }
     end
 
-    it "does not commit changes to the index" do
+    it "commits changes to the index" do
       person = Person.create(:name => "Kato")
 
       expect do
         job.perform(Person, person.id)
-      end.to_not change { Person.search.hits.size }
-
-      expect do
-        commit
       end.to change { Person.search.hits.size }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,12 @@ class Person < ActiveRecord::Base
   end
 end
 
+class Rails
+  def self.version
+    '4'
+  end
+end
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
@@ -84,7 +90,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :backend => :delayed_job) do
-    Delayed::Worker.delay_jobs = false 
+    Delayed::Worker.delay_jobs = false
 
     require "sunspot/queue/delayed_job"
     backend = Sunspot::Queue::DelayedJob::Backend.new


### PR DESCRIPTION
I've done some refactoring, fixed some specs that are failing and finally ``Index`` and ``Removal`` classes are using sunspot ``autocommit`` by default.