### PR TITLE
Adds ability to ask objects if they should be indexed or removed.

### DIFF
--- a/lib/sunspot/queue/session_proxy.rb
+++ b/lib/sunspot/queue/session_proxy.rb
@@ -16,7 +16,9 @@ module Sunspot::Queue
       end
 
       objects.each do |object|
-        @backend.index(object.class.name, object.id)
+        if eligible_for_index?(object)
+          @backend.index(object.class.name, object.id)
+        end
       end
     end
     alias :index! :index
@@ -31,7 +33,7 @@ module Sunspot::Queue
           # We're assuming if it doesn't have an id then it hasn't been
           # persisted and can safely be ignored since it shouldn't exist in the
           # search index.
-          if object.id
+          if object.id && eligible_for_index?(object)
             @backend.remove(object.class.name, object.id)
           end
         end
@@ -103,6 +105,16 @@ module Sunspot::Queue
 
     def dirty?
       false
+    end
+
+    private
+
+    def eligible_for_index?(object)
+      if object.respond_to?(:eligible_for_index?) 
+        object.eligible_for_index?
+      else
+        true
+      end
     end
   end
 end

--- a/lib/sunspot/queue/sidekiq/index_job.rb
+++ b/lib/sunspot/queue/sidekiq/index_job.rb
@@ -1,3 +1,4 @@
+require "sidekiq"
 require "sidekiq/worker"
 require "sunspot/queue/helpers"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,8 +36,18 @@ Sunspot::Adapters::DataAccessor.register(Sunspot::Rails::Adapters::ActiveRecordD
 class Person < ActiveRecord::Base
   include Sunspot::Rails::Searchable
 
+  attr_accessor :index_me
+
   searchable do
     text :name
+  end
+
+  def eligible_for_index?
+    if index_me.nil?
+      true
+    else
+      index_me
+    end
   end
 end
 


### PR DESCRIPTION
This allows the instance to determine if it should be enqueued for index adds/removals based on things like certain states. So an order for example would not be enqueued at all until it changed from a CART state.

``` ruby
class Order < ActiveRecord::Base
  def eligible_for_index?
    status != CART
  end
end
```

If an AR instance does not implement `eligible_for_index?` it's assumed business as usual :smile: 
