### PR TITLE
Adding support for performing the indexing in real time in case an error occurs when enqueueing the job.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Sunspot::Queue.configure do |config|
   # Override default job classes
   config.index_job   = CustomIndexJob
   config.removal_job = CustomRemovalJob
+
+  # In case a failure on scheduling the job (Redis::TimeoutError for example), try to execute it
+  # in real time. 
+  config.force_index_on_failure = false
 end
 ```
 

--- a/lib/sunspot/queue/configuration.rb
+++ b/lib/sunspot/queue/configuration.rb
@@ -1,5 +1,5 @@
 module Sunspot::Queue
   class Configuration
-    attr_accessor :index_job, :removal_job
+    attr_accessor :index_job, :removal_job, :force_index_on_failure
   end
 end

--- a/lib/sunspot/queue/delayed_job/backend.rb
+++ b/lib/sunspot/queue/delayed_job/backend.rb
@@ -12,6 +12,12 @@ module Sunspot::Queue::DelayedJob
 
     def enqueue(job)
       Delayed::Job.enqueue(job)
+    rescue => e
+      if configuration.force_index_on_failure
+        job.perform
+      else
+        raise e
+      end
     end
 
     def index(klass, id)

--- a/lib/sunspot/queue/resque/backend.rb
+++ b/lib/sunspot/queue/resque/backend.rb
@@ -12,6 +12,12 @@ module Sunspot::Queue::Resque
 
     def enqueue(job, klass, id)
       ::Resque.enqueue(job, klass, id)
+    rescue => e
+      if configuration.force_index_on_failure
+        job.perform(klass, id)
+      else
+        raise e
+      end
     end
 
     def index(klass, id)

--- a/lib/sunspot/queue/sidekiq/backend.rb
+++ b/lib/sunspot/queue/sidekiq/backend.rb
@@ -12,6 +12,12 @@ module Sunspot::Queue::Sidekiq
     # Job needs to include Sidekiq::Worker
     def enqueue(job, klass, id)
       job.perform_async(klass.to_s, id)
+    rescue => e
+      if configuration.force_index_on_failure
+        job.perform(klass.to_s, id)
+      else
+        raise e
+      end
     end
 
     def index(klass, id)

--- a/lib/sunspot/queue/sidekiq/index_job.rb
+++ b/lib/sunspot/queue/sidekiq/index_job.rb
@@ -1,3 +1,4 @@
+require "sidekiq"
 require "sidekiq/worker"
 require "sunspot/queue/helpers"
 

--- a/spec/sidekiq/backend_spec.rb
+++ b/spec/sidekiq/backend_spec.rb
@@ -28,6 +28,22 @@ describe Sunspot::Queue::Sidekiq::Backend do
         backend.index(Person, 11)
       end.to change { ::Sunspot::Queue::Sidekiq::IndexJob.jobs.size }.by(1)
     end
+
+    it "performs the job in real time in case of failure queueing the job" do
+      configuration.force_index_on_failure = true
+      Sunspot::Queue::Sidekiq::IndexJob.should_receive(:perform_async) { raise 'some error' }
+      Sunspot::Queue::Sidekiq::IndexJob.should_receive(:perform).with('Person', 12)
+
+      backend.index(Person, 12)
+    end
+
+    it "raises the error witout performing the job in real time in case of failure queueing the job" do
+      configuration.force_index_on_failure = false
+      Sunspot::Queue::Sidekiq::IndexJob.should_receive(:perform_async) { raise 'some error' }
+      Sunspot::Queue::Sidekiq::IndexJob.should_not_receive(:perform)
+
+      expect { backend.index(Person, 12) }.to raise_error('some error')
+    end
   end
 
   describe "#remove" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,12 @@ class Person < ActiveRecord::Base
   end
 end
 
+class Rails
+  def self.version
+    '4'
+  end
+end
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
@@ -84,7 +90,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :backend => :delayed_job) do
-    Delayed::Worker.delay_jobs = false 
+    Delayed::Worker.delay_jobs = false
 
     require "sunspot/queue/delayed_job"
     backend = Sunspot::Queue::DelayedJob::Backend.new


### PR DESCRIPTION
In my case, sometimes the enqueue fails because or redis timeouts (Redis::TimeoutError: Connection timed out) and because indexing jobs are critical this gives us a way to not lose them and to index the element is real time (which in most of the cases is better than just not indexing them).