### PR TITLE
Ignore default scopes when retrieving active records

### DIFF
--- a/lib/sunspot/queue/delayed_job/index_job.rb
+++ b/lib/sunspot/queue/delayed_job/index_job.rb
@@ -6,7 +6,7 @@ module Sunspot::Queue::DelayedJob
 
     def perform
       without_proxy do
-        constantize(klass).find(id).solr_index
+        constantize(klass).unscoped.find(id).solr_index
       end
     end
   end


### PR DESCRIPTION
Currently sunspot-queue will fail to retrieve active records if default scopes filter them out. This PR unscopes the default scopes first so that they're always found.
